### PR TITLE
Fix plugin directory constant references

### DIFF
--- a/flexline-utilities.php
+++ b/flexline-utilities.php
@@ -28,8 +28,8 @@ define('FLEXLINE_UTILITIES_VERSION', '1.0.0');
 define('FLEXLINE_UTILITIES_PLUGIN_DIR', plugin_dir_path(__FILE__));
 
 // Include required files.
-require_once WEB4SL_PLUGIN_DIR . 'includes/class-shortcodes.php';
-require_once WEB4SL_PLUGIN_DIR . 'includes/class-utilities.php';
+require_once FLEXLINE_UTILITIES_PLUGIN_DIR . 'includes/class-shortcodes.php';
+require_once FLEXLINE_UTILITIES_PLUGIN_DIR . 'includes/class-utilities.php';
 
 
 // Activation and deactivation hooks.


### PR DESCRIPTION
## Summary
- Use `FLEXLINE_UTILITIES_PLUGIN_DIR` in require_once statements

## Testing
- `php -l flexline-utilities.php`


------
https://chatgpt.com/codex/tasks/task_e_68a71a64eb64832b90f875c6c097b2a7