### PR TITLE
Add theme docs asset enqueuing

### DIFF
--- a/includes/class-shortcodes.php
+++ b/includes/class-shortcodes.php
@@ -93,5 +93,39 @@ class Shortcodes {
         // Return the buffered content.
         return ob_get_clean();
     }
-    
+
 }
+
+/**
+ * Enqueue assets for the theme docs shortcode.
+ */
+function enqueue_theme_docs_assets() {
+    if ( ! is_singular() ) {
+        return;
+    }
+
+    $post = get_post();
+    if ( ! $post || ! has_shortcode( $post->post_content, 'flexline_theme_docs' ) ) {
+        return;
+    }
+
+    wp_enqueue_style( 'dashicons' );
+
+    $theme_uri = get_template_directory_uri();
+    wp_enqueue_script(
+        'flexline-tablesort',
+        $theme_uri . '/assets/js/tablesort.js',
+        array(),
+        null,
+        true
+    );
+    wp_enqueue_script(
+        'flexline-theme-docs',
+        $theme_uri . '/assets/js/theme-docs.js',
+        array( 'flexline-tablesort' ),
+        null,
+        true
+    );
+}
+
+add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_theme_docs_assets' );


### PR DESCRIPTION
## Summary
- add enqueue_theme_docs_assets function to load dashicons and theme docs scripts

## Testing
- `php -l includes/class-shortcodes.php`
- `php -l flexline-utilities.php`


------
https://chatgpt.com/codex/tasks/task_e_68a71a4d93e8832bbb8c88678d574547