### PR TITLE
Add FlexLine Utilities admin page with shortcode section

### DIFF
--- a/flexline-utilities.php
+++ b/flexline-utilities.php
@@ -28,6 +28,7 @@ define('FLEXLINE_UTILITIES_VERSION', '1.0.0');
 define('FLEXLINE_UTILITIES_PLUGIN_DIR', plugin_dir_path(__FILE__));
 
 // Include required files.
+require_once FLEXLINE_UTILITIES_PLUGIN_DIR . 'includes/class-admin.php';
 require_once FLEXLINE_UTILITIES_PLUGIN_DIR . 'includes/class-shortcodes.php';
 require_once FLEXLINE_UTILITIES_PLUGIN_DIR . 'includes/class-utilities.php';
 
@@ -55,6 +56,7 @@ add_action('plugins_loaded', 'FlexLine_Utilities\init');
 
 function init() {
     Shortcodes::init();
+    Admin::init();
     add_action('wp_enqueue_scripts', 'FlexLine_Utilities\enqueue_scripts');
 }
 

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -1,0 +1,56 @@
+<?php
+namespace FlexLine_Utilities;
+
+class Admin {
+    public static function init() {
+        add_action(
+            'admin_menu',
+            function () {
+                add_submenu_page(
+                    'flexline_theme_options',
+                    'FlexLine Utilities',
+                    'FlexLine Utilities',
+                    'manage_options',
+                    'flexline-utilities',
+                    [ __CLASS__, 'render_page' ]
+                );
+            }
+        );
+    }
+
+    public static function render_page() {
+        ?>
+        <div class="wrap">
+            <h1>FlexLine Utilities</h1>
+            <h2>Shortcodes</h2>
+            <table class="widefat fixed striped">
+                <thead>
+                    <tr>
+                        <th>Shortcode</th>
+                        <th>Usage</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td><code>[flexline_copyright_year]</code></td>
+                        <td><code>[flexline_copyright_year starting_year="2015"]</code></td>
+                    </tr>
+                    <tr>
+                        <td><code>[flexline_theme_docs]</code></td>
+                        <td><code>[flexline_theme_docs]</code></td>
+                    </tr>
+                    <tr>
+                        <td><code>[flexline_site_name]</code></td>
+                        <td><code>[flexline_site_name]</code></td>
+                    </tr>
+                    <tr>
+                        <td><code>[flexline_page_title]</code></td>
+                        <td><code>[flexline_page_title]</code></td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+        <?php
+    }
+}
+


### PR DESCRIPTION
## Summary
- Add FlexLine Utilities submenu under theme options and prepare for future sections
- List available shortcode examples under a dedicated Shortcodes section

## Testing
- `php -l includes/class-admin.php`
- `php -l flexline-utilities.php`


------
https://chatgpt.com/codex/tasks/task_e_68a7a40d23c0832b83cad4e1d22a3b2b