### PR TITLE
Refactor admin menu registration

### DIFF
--- a/flexline-utilities.php
+++ b/flexline-utilities.php
@@ -32,6 +32,8 @@ require_once FLEXLINE_UTILITIES_PLUGIN_DIR . 'includes/class-admin.php';
 require_once FLEXLINE_UTILITIES_PLUGIN_DIR . 'includes/class-shortcodes.php';
 require_once FLEXLINE_UTILITIES_PLUGIN_DIR . 'includes/class-utilities.php';
 
+// Hook admin menu.
+add_action( 'admin_menu', [ FlexLine_Utilities\Admin::class, 'init' ] );
 
 // Activation and deactivation hooks.
 register_activation_hook(__FILE__, 'FlexLine_Utilities\activate');
@@ -56,7 +58,6 @@ add_action('plugins_loaded', 'FlexLine_Utilities\init');
 
 function init() {
     Shortcodes::init();
-    Admin::init();
     add_action('wp_enqueue_scripts', 'FlexLine_Utilities\enqueue_scripts');
 }
 

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -3,18 +3,13 @@ namespace FlexLine_Utilities;
 
 class Admin {
     public static function init() {
-        add_action(
-            'admin_menu',
-            function () {
-                add_submenu_page(
-                    'flexline_theme_options',
-                    'FlexLine Utilities',
-                    'FlexLine Utilities',
-                    'manage_options',
-                    'flexline-utilities',
-                    [ __CLASS__, 'render_page' ]
-                );
-            }
+        add_submenu_page(
+            'flexline_theme_options',
+            'FlexLine Utilities',
+            'FlexLine Utilities',
+            'manage_options',
+            'flexline-utilities',
+            [ __CLASS__, 'render_page' ]
         );
     }
 


### PR DESCRIPTION
## Summary
- Register utilities submenu directly within `Admin::init()`
- Hook `Admin::init()` to `admin_menu` and remove redundant call in `init`

## Testing
- `php -l includes/class-admin.php`
- `php -l flexline-utilities.php`

------
https://chatgpt.com/codex/tasks/task_e_68a7af3d26cc832b84206fc78d091c29