### PR TITLE
Use Admin::render_page callback for admin menu

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -9,11 +9,11 @@ class Admin {
 
     public static function add_admin_menu() {
         add_theme_page(
-            'FlexLine Utilities', 
-            'FlexLine Utilities', 
-            'manage_options', 
-            'flexline_utilities', 
-            'flexline_utilities_page'
+            'FlexLine Utilities',
+            'FlexLine Utilities',
+            'manage_options',
+            'flexline_utilities',
+            array(__CLASS__, 'render_page')
         );
         
     }


### PR DESCRIPTION
## Summary
- Hook FlexLine Utilities admin menu to render_page callback instead of string placeholder

## Testing
- `php -l includes/class-admin.php`
- `php -r "include 'includes/class-admin.php'; FlexLine_Utilities\\Admin::render_page();" | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68a7daa93dd8832b8fbfba02b4f81b2e