### PR TITLE
Document FlexLine shortcodes with descriptions and attributes

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -24,30 +24,52 @@ class Admin {
         <div class="wrap">
             <h1>FlexLine Utilities</h1>
             <h2>Shortcodes</h2>
+            <?php
+            $shortcodes = array(
+                array(
+                    'tag'         => 'flexline_copyright_year',
+                    'usage'       => '[flexline_copyright_year starting_year="2015"]',
+                    'description' => 'Displays the current year or a range from a starting year to the current year.',
+                    'attributes'  => 'starting_year, separator',
+                ),
+                array(
+                    'tag'         => 'flexline_theme_docs',
+                    'usage'       => '[flexline_theme_docs]',
+                    'description' => 'Renders the FlexLine theme documentation tab.',
+                    'attributes'  => '&mdash;',
+                ),
+                array(
+                    'tag'         => 'flexline_site_name',
+                    'usage'       => '[flexline_site_name]',
+                    'description' => 'Outputs the site name.',
+                    'attributes'  => '&mdash;',
+                ),
+                array(
+                    'tag'         => 'flexline_page_title',
+                    'usage'       => '[flexline_page_title]',
+                    'description' => 'Outputs the current page title.',
+                    'attributes'  => '&mdash;',
+                ),
+            );
+            ?>
             <table class="widefat fixed striped">
                 <thead>
                     <tr>
                         <th>Shortcode</th>
                         <th>Usage</th>
+                        <th>Description</th>
+                        <th>Attributes</th>
                     </tr>
                 </thead>
                 <tbody>
+                <?php foreach ( $shortcodes as $shortcode ) : ?>
                     <tr>
-                        <td><code>[flexline_copyright_year]</code></td>
-                        <td><code>[flexline_copyright_year starting_year="2015"]</code></td>
+                        <td><code>[<?php echo esc_html( $shortcode['tag'] ); ?>]</code></td>
+                        <td><code><?php echo esc_html( $shortcode['usage'] ); ?></code></td>
+                        <td><?php echo esc_html( $shortcode['description'] ); ?></td>
+                        <td><?php echo esc_html( $shortcode['attributes'] ); ?></td>
                     </tr>
-                    <tr>
-                        <td><code>[flexline_theme_docs]</code></td>
-                        <td><code>[flexline_theme_docs]</code></td>
-                    </tr>
-                    <tr>
-                        <td><code>[flexline_site_name]</code></td>
-                        <td><code>[flexline_site_name]</code></td>
-                    </tr>
-                    <tr>
-                        <td><code>[flexline_page_title]</code></td>
-                        <td><code>[flexline_page_title]</code></td>
-                    </tr>
+                <?php endforeach; ?>
                 </tbody>
             </table>
         </div>


### PR DESCRIPTION
## Summary
- add description and attributes columns to shortcode table
- centralize shortcode metadata in array for easier maintenance

## Testing
- `php -l includes/class-admin.php`

------
https://chatgpt.com/codex/tasks/task_e_68a7ddf8826c832bb1c0c047727e7f8f